### PR TITLE
Fix #12

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -158,6 +158,8 @@ class Game {
       if (!block.fixed) {
         if (this.shouldFix(block)) {
           block.fixed = true;
+          this.clearRows(this.rowsToClear(block));
+          return;
         }
 
         this.move(block, 1);


### PR DESCRIPTION
block motion logic still activated when a block should be fixed, which made this issue happen.  adding a return **should** fix it, if I'm reading right.